### PR TITLE
Allow the "npm start" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Finding domains to use for domain fronting",
   "main": "app.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
This makes you able to write `npm start`, and then start the service. This is easier than having to know the entry point for new users, and plays will with NPM.